### PR TITLE
fixes to pyccs installation

### DIFF
--- a/pyccs/server.py
+++ b/pyccs/server.py
@@ -41,17 +41,34 @@ def _find_library() -> str:
     import sys
     import platform
 
-    local_dir = os.path.join(sys.prefix, 'lib')
     this_system = platform.system().lower()
-    try:
-        if this_system == "darwin":
-            lib_path = os.path.join(local_dir, 'libccs-client.dylib')
-        else:
-            lib_path = os.path.join(local_dir, 'libccs-client.so')
-        assert os.path.exists(lib_path)
-        return lib_path
-    except:
-        raise
+
+    # regular case 
+    system_lib_dir = os.path.join(sys.prefix, 'lib')
+    if this_system == "darwin":
+        system_lib_path = os.path.join(system_lib_dir, 'libccs-client.dylib')
+    else:
+        system_lib_path = os.path.join(system_lib_dir, 'libccs-client.so')
+
+    if os.path.exists(system_lib_path):
+        return system_lib_path
+
+    # other case user base directory (~/.local/lib/)
+    user_lib_dir = os.path.join(os.path.expanduser("~"), '.local', 'lib')
+    if this_system == "darwin":
+        user_lib_path = os.path.join(user_lib_dir, 'libccs-client.dylib')
+    else:
+        user_lib_path = os.path.join(user_lib_dir, 'libccs-client.so')
+
+    if os.path.exists(user_lib_path):
+        return user_lib_path
+
+    raise FileNotFoundError(
+        f"Library not found. Checked locations:\n"
+        f"  1. {system_lib_path}\n"
+        f"  2. {user_lib_path}\n"
+        f"Ensure libccs-client.so is installed in one of these locations."
+    )
 
 @dataclass
 class ConnectionInfo:

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,19 @@ def get_build_os():
     return os.lower()
 
 system = get_build_os()
+libccs_client = None
 
 if system == "darwin":
     try:
         assert os.path.exists('charm_src/charm/lib_so/libccs-client.dylib')
+        libccs_client = 'charm_src/charm/lib_so/libccs-client.dylib'
     except AssertionError:
         print("ERROR: Library file 'charm_src/charm/lib_so/libccs-client.dylib' not found!")
         raise
 else:
     try:
         assert os.path.exists('charm_src/charm/lib_so/libccs-client.so')
+        libccs_client = 'charm_src/charm/lib_so/libccs-client.so'
     except AssertionError:
         print("ERROR: Library file 'charm_src/charm/lib_so/libccs-client.so' not found!")
         raise
@@ -50,5 +53,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    data_files=[('lib', ['charm_src/charm/lib_so/libccs-client.dylib'])]
+    data_files=[('lib', [libccs_client])]
 )


### PR DESCRIPTION
-change data-files argument so it isn't hardcoded to the .dylib version 
-the libccs file installed inside my .local/lib directory so added support so it looks in that folder for the file as well. Don't know if this is an anomaly just for me but if we feel that it's not necessary to add the second check we can get rid of it as well. 